### PR TITLE
[ADD] additional out-of template requirements for special modules

### DIFF
--- a/build
+++ b/build
@@ -25,6 +25,6 @@ fi
 . .venv/bin/activate && \
 pip install "setuptools<58" && \
 pip install "pip>=20.3" && \
-pip install -r requirements.txt && \
+pip install -r requirements.txt && pip install -r extra_requirements.txt ; \
 ./common/build && \
 python $ODOO_WORK_DIR/common/entrypoint


### PR DESCRIPTION
@thomaspaulb don;t know if im using this right, but i needed an additional pip installation of acme, dnspython in the project to get it working. these libs are not in the requirements.txt template of waft10 and i thought that changing the template just for letsencrypt libraries was a bad idea. 

so i changed build to also install  libs in the optional file  "extra requirements.txt", and it won't fail if file does not exist.

If there was a better way , ignore and point me to the right way.