### PR TITLE
[ADD] correct error message

### DIFF
--- a/bootstrap
+++ b/bootstrap
@@ -20,8 +20,8 @@ if [ -z "$LIBRARIES_VERSION_BRANCH" ]; then
     /bin/echo "INFO: END"
     exit 0
   else
-    /bin/echo "ERROR: $ODOO_WORK_DIR/bootstrap files does not have 'LIBRARIES_VERSION_BRANCH' variable! update it by this command:"
-    /bin/echo "  /usr/bin/curl https://raw.githubusercontent.com/sunflowerit/waft/master/bootstrap -o $ODOO_WORK_DIR/bootstrap"
+    /bin/echo "ERROR: $SCRIPT_PATH/bootstrap files does not have 'LIBRARIES_VERSION_BRANCH' variable! update it by this command:"
+    /bin/echo "  /usr/bin/curl https://raw.githubusercontent.com/sunflowerit/waft/master/bootstrap -o $SCRIPT_PATH/bootstrap"
     exit 1
   fi
 fi


### PR DESCRIPTION
Change in the error message.

Example:
 I am in  /home/gcapalbo/k240/icapps16/w16

i execute command ./bootstrap

Before:
         `
ERROR: /home/gcapalbo/k240/icapps16/bootstrap files does not have 'LIBRARIES_VERSION_BRANCH' variable! update it by this command:
  /usr/bin/curl https://raw.githubusercontent.com/sunflowerit/waft/master/bootstrap -o /home/gcapalbo/k240/icapps16/bootstrap
`
after
`
ERROR: /home/gcapalbo/k240/icapps16/w16/bootstrap files does not have 'LIBRARIES_VERSION_BRANCH' variable! update it by this command:
  /usr/bin/curl https://raw.githubusercontent.com/sunflowerit/waft/master/bootstrap -o /home/gcapalbo/k240/icapps16/w16/bootstrap
`
