### PR TITLE
[IMP] Add datadir to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ auto/*
 auto/addons/*
 !auto/addons/.gitkeep
 odoo-variables
+datadir
 logfile
 qa/*
 !qa/artifacts


### PR DESCRIPTION
Having a data directory inside an Odoo instance based on waft makes it easy to have self-contained deployments, which is especially handy for local development environments.

This change just enables a local data directory, it changes nothing in the default installation location.