### PR TITLE
[IMP] Keep addons config in addons.yaml

### DIFF
--- a/waftlib/__init__.py
+++ b/waftlib/__init__.py
@@ -108,8 +108,7 @@ def addons_config(filtered=True, strict=False):
                     if repo == "ENV":
                         continue
                     logger.debug("Processing %s repo", repo)
-                    all_globs.setdefault(repo, set())
-                    all_globs[repo].update(partial_globs)
+                    all_globs[repo] = partial_globs
     except IOError:
         logger.debug("Could not find addons configuration yaml.")
     # Add default values for special sections
@@ -178,17 +177,14 @@ except ImportError:
     def which(binary):
         return check_output(["which", binary]).strip()
 
+
 def addons_in_repos_config():
     globs = {}
     try:
         with open(REPOS_YAML) as repos_file:
             for doc in yaml.safe_load_all(repos_file):
                 for repo, object in doc.items():
-                    if "restrict_modules" in object:
-                        if object["restrict_modules"]:
-                            globs[repo] = object["restrict_modules"]
-                    else:
-                        globs[repo] = ["*"]
+                    globs[repo] = ["*"]
     except IOError:
         logger.error("Could not find repos configuration yaml.")
         exit(1)


### PR DESCRIPTION
I think it would be best to keep the addons configuration in addons.yaml.

With the present proposal the addons to use for a repository can be configured in two ways. Either with an extra key restrict_modules in repos.yaml, or by listing them under the repo name in addons.yaml.

The disadvantage IMHO is that we introduce a new kind of key in repos.yaml. Even though that is supported, it seems out of place. Also it seems better to me to have one way to do things.

I tested this solution both with no addons.yaml at all and with addons.yaml just containing:
```
OCA/server-env:
    - mail_environment
    - server_environment
```