### PR TITLE
[IMP] [no task] Moved the translate-modules script to into a seperate…

### DIFF
--- a/bootstrap
+++ b/bootstrap
@@ -273,8 +273,8 @@ else
 fi
 
 if [ ! -f "${ODOO_WORK_DIR}/translate-modules" ] || [ -L "${ODOO_WORK_DIR}/translate-modules" ]; then
-  /bin/echo "INFO: Link ${ODOO_WORK_DIR}/waftlib/bin/translate-modules to ${ODOO_WORK_DIR}/translate-modules"
-  cd "${ODOO_WORK_DIR}" && /bin/ln -sf waftlib/bin/translate-modules
+  /bin/echo "INFO: Link ${ODOO_WORK_DIR}/waftlib/translate-modules to ${ODOO_WORK_DIR}/translate-modules"
+  cd "${ODOO_WORK_DIR}" && /bin/ln -sf waftlib/translate-modules
 else
   /bin/echo "WARNING: ${ODOO_WORK_DIR}/translate-modules not a default link!"
 fi

--- a/templates/12.0/requirements-default.txt
+++ b/templates/12.0/requirements-default.txt
@@ -23,6 +23,7 @@ colorama==0.4.4
 contextlib2==0.6.0.post1
 cssselect==1.1.0
 decorator==4.0.10
+deepl==1.14.0; python_version >= "3.6"
 docutils==0.14
 ebaysdk==2.1.5
 feedparser==5.2.1

--- a/templates/13.0/requirements-default.txt
+++ b/templates/13.0/requirements-default.txt
@@ -27,6 +27,7 @@ contextlib2==0.6.0.post1
 cssselect==1.1.0
 dateparser==1.0.0
 decorator==4.0.10
+deepl==1.14.0; python_version >= "3.6"
 defusedxml==0.7.1
 Deprecated==1.2.12
 docutils==0.14

--- a/templates/14.0/requirements-default.txt
+++ b/templates/14.0/requirements-default.txt
@@ -22,6 +22,7 @@ colorama==0.4.4
 cssselect==1.1.0
 dateparser==1.1.1
 decorator==4.3.0
+deepl==1.14.0; python_version >= "3.6"
 defusedxml==0.7.1
 docutils==0.14
 ebaysdk==2.1.5

--- a/templates/15.0/requirements-default.txt
+++ b/templates/15.0/requirements-default.txt
@@ -22,6 +22,7 @@ colorama==0.4.4
 cryptography==38.0.1
 cssselect==1.1.0
 decorator==4.4.2
+deepl==1.14.0
 defusedxml==0.7.1
 docutils==0.16
 ebaysdk==2.1.5

--- a/templates/16.0/requirements-default.txt
+++ b/templates/16.0/requirements-default.txt
@@ -22,6 +22,7 @@ colorama==0.4.4
 cryptography==38.0.1
 cssselect==1.1.0
 decorator==4.4.2
+deepl==1.14.0
 defusedxml==0.7.1
 docutils==0.16
 ebaysdk==2.1.5

--- a/translate-modules
+++ b/translate-modules
@@ -1,0 +1,9 @@
+SCRIPT_PATH="$(cd "$(/usr/bin/dirname "${0}")" && /bin/pwd)"
+export ODOO_WORK_DIR="${SCRIPT_PATH}"
+. "${ODOO_WORK_DIR}/.env-default" && \
+. "${ODOO_WORK_DIR}/.env-shared" && \
+. "${ODOO_WORK_DIR}/.env-secret"
+export DEEPL_SECRET=$DEEPL_SECRET
+export PGDATABASE=$PGDATABASE
+
+${ODOO_WORK_DIR}/.venv/bin/python "$SCRIPT_PATH/waftlib/bin/translate-modules.py" $@


### PR DESCRIPTION
… file that is invoked by a bash script.

The translate-modules script was having problems because it used the waftlib package, which is available in the virtual environment. So in order to use the virtual environment, the python script needed to be moved invoked by a bash script so that it can use `.venv/bin/python`. But the use of the bash script removed the need for the waftlib import alltogether, so `.venv/bin/python` is not necessarily needed over the system's python binary. However, it is still useful to use the virtual environment, because the translate-modules script depends on package `deepl` when using the `--use-translation-service` option, and deepl can be made available in the virtual environment.