### PR TITLE
[IMP] use no-color switch if available

### DIFF
--- a/bin/autoaggregate
+++ b/bin/autoaggregate
@@ -5,7 +5,7 @@ import os
 import sys
 from dotenv import load_dotenv
 from multiprocessing import cpu_count
-from subprocess import check_call
+from subprocess import check_call, check_output
 
 import yaml
 from waftlib import (
@@ -46,6 +46,13 @@ def aggregate(config):
             old_umask = os.umask(int(UMASK))
         cmd = [
             "gitaggregate",
+            "-h",
+        ]
+        has_no_color_switch = b"no-color" in check_output(cmd)
+        cmd = ["gitaggregate"]
+        if has_no_color_switch:
+            cmd.append("--no-color")
+        cmd += [
             "--expand-env",
             "--config",
             config,


### PR DESCRIPTION
This is to have more readable output when we get a "nightly failed" email