### PR TITLE
[FIX] workers should be configured in odoo.cfg

### DIFF
--- a/run
+++ b/run
@@ -8,4 +8,4 @@ ODOO_WORK_DIR="${SCRIPT_PATH}"
 . "${ODOO_WORK_DIR}/.env-secret"
 cd "${ODOO_WORK_DIR}"
 
-. "${ODOO_WORK_DIR}/.venv/bin/activate" && odoo -c ./auto/odoo.conf --workers=0 $*
+. "${ODOO_WORK_DIR}/.venv/bin/activate" && odoo -c ./auto/odoo.conf $*


### PR DESCRIPTION
Running with --workers=0 on commandline forces Odoo to run the multi-threaded server instead of the multi-processing server. The multi-processing server has better performance and is recommended on production.