### PR TITLE
[IMP] #9242 Survive broken 'git am' patches

### DIFF
--- a/build.d/050-pre-clean
+++ b/build.d/050-pre-clean
@@ -36,6 +36,15 @@ for directory in repos:
     if not os.path.isdir(os.path.join(directory, '.git/objects')):
         shutil.rmtree(directory)
         continue
+    # https://stackoverflow.com/q/3921409
+    # TODO: more subtle to call "git am --abort"
+    if os.path.isdir(os.path.join(directory, '.git/rebase-apply')):
+        shutil.rmtree(directory)
+        continue
+    # TODO: more subtle to call "git merge --abort"
+    if os.path.isdir(os.path.join(directory, '.git/rebase-merge')):
+        shutil.rmtree(directory)
+        continue
     try:
         check_call(
             [


### PR DESCRIPTION
We recently started using a new way of applying MR's to branches. Instead of letting gitaggregator merge, we apply a shell_command_after that applies the MR as a 'git am' patch, which preserves pinning. However when 'git am' fails, the directory is left in a broken state and this should be fixed upon rebuild.